### PR TITLE
brightness under backlight off

### DIFF
--- a/custom_components/hasp_lvgl/__init__.py
+++ b/custom_components/hasp_lvgl/__init__.py
@@ -223,7 +223,7 @@ class SwitchPlate(RestoreEntity):
                 self._dim = self._idle_brightness
                 self._backlight = 1
             elif message == HASP_IDLE_LONG:
-                self._dim = self._awake_brightness
+                self._dim = self._idle_brightness
                 self._backlight = 0
 
             _LOGGER.debug(


### PR DESCRIPTION
_idle_brightness suits better when _backlight is 0, for automations to turn on display during the day and turn it off during the night. With _awake_brightness it flashed once which was annoying.

tested with
```yaml
- alias: "lanbon-day"
  trigger:
    platform: numeric_state
    entity_id: sun.sun
    value_template: "{{ state_attr('sun.sun', 'elevation') }}"
    above: -1
  action:
    - service: mqtt.publish
      data:
        topic: hasp/plate/config/gui
        payload: "{'idle2':0}"
```